### PR TITLE
Run rubocop auto-correct and remove hardcoded OAuth secrets

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 # Load DSL and set up stages
-require "capistrano/setup"
+require 'capistrano/setup'
 
 # Include default deployment tasks
-require "capistrano/deploy"
+require 'capistrano/deploy'
 
 # Load the SCM plugin appropriate to your project:
 #
@@ -12,7 +14,7 @@ require "capistrano/deploy"
 # require "capistrano/scm/svn"
 # install_plugin Capistrano::SCM::Svn
 # or
-require "capistrano/scm/git"
+require 'capistrano/scm/git'
 install_plugin Capistrano::SCM::Git
 
 # Include tasks from other gems included in your Gemfile
@@ -42,4 +44,4 @@ set :rbenv_type, :user
 set :rbenv_ruby, '3.2.2'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
-Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
+Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative "config/application"
+require_relative 'config/application'
 
 Rails.application.load_tasks

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -63,13 +63,11 @@ class PhotosController < ApplicationController
 
   def destroy
     @photo = Photo.find_by(uuid: params[:uuid])
-    if @photo.user != current_user
-      return head :unauthorized
-    else
-      @photo.destroy
+    return head :unauthorized if @photo.user != current_user
 
-      redirect_to root_path, status: :see_other
-    end
+    @photo.destroy
+
+    redirect_to root_path, status: :see_other
   end
 
   private

--- a/app/controllers/sessions/omniauth_controller.rb
+++ b/app/controllers/sessions/omniauth_controller.rb
@@ -1,37 +1,39 @@
 # frozen_string_literal: true
 
-class Sessions::OmniauthController < ApplicationController
-  skip_before_action :verify_authenticity_token
-  skip_before_action :require_auth!
+module Sessions
+  class OmniauthController < ApplicationController
+    skip_before_action :verify_authenticity_token
+    skip_before_action :require_auth!
 
-  def create
-    @user = User.create_with(user_params).find_or_initialize_by(omniauth_params)
+    def create
+      @user = User.create_with(user_params).find_or_initialize_by(omniauth_params)
 
-    if @user.save
-      reset_session
-      session[:user_id] = @user.id
+      if @user.save
+        reset_session
+        session[:user_id] = @user.id
 
-      redirect_to root_path, notice: 'Signed in'
-    else
-      redirect_to sign_in_path, alert: 'Authentication failed'
+        redirect_to root_path, notice: 'Signed in'
+      else
+        redirect_to sign_in_path, alert: 'Authentication failed'
+      end
     end
-  end
 
-  def failure
-    redirect_to sign_in_path, alert: params[:message]
-  end
+    def failure
+      redirect_to sign_in_path, alert: params[:message]
+    end
 
-  private
+    private
 
-  def user_params
-    { email: omniauth.info.email }
-  end
+    def user_params
+      { email: omniauth.info.email }
+    end
 
-  def omniauth_params
-    { provider: omniauth.provider, uid: omniauth.uid }
-  end
+    def omniauth_params
+      { provider: omniauth.provider, uid: omniauth.uid }
+    end
 
-  def omniauth
-    request.env['omniauth.auth']
+    def omniauth
+      request.env['omniauth.auth']
+    end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
-  skip_before_action :require_auth!, only: %i[ new ]
+  skip_before_action :require_auth!, only: %i[new]
 
   def new
     @user = User.new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/app/helpers/photos_helper.rb
+++ b/app/helpers/photos_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module PhotosHelper
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
-  layout "mailer"
+  default from: 'from@example.com'
+  layout 'mailer'
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Photo < ApplicationRecord
   belongs_to :user
 
@@ -5,7 +7,7 @@ class Photo < ApplicationRecord
     attachable.variant :medium, resize_to_limit: [960, 960]
   end
 
-  validates :title, :presence => true
+  validates :title, presence: true
 
   before_create do
     require 'securerandom'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   has_many :photos, dependent: :destroy
 

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
-require_relative "config/environment"
+require_relative 'config/environment'
 
 run Rails.application
 Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,8 @@
-require_relative "boot"
+# frozen_string_literal: true
 
-require "rails/all"
+require_relative 'boot'
+
+require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,6 @@
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+# frozen_string_literal: true
 
-require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+
+require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,9 +1,11 @@
-# config valid for current version and patch releases of Capistrano
-lock "~> 3.17.2"
+# frozen_string_literal: true
 
-set :application, "mimages"
-set :repo_url, "git@github.com:bamnet/mimages.git"
-set :branch, "main"
+# config valid for current version and patch releases of Capistrano
+lock '~> 3.17.2'
+
+set :application, 'mimages'
+set :repo_url, 'git@github.com:bamnet/mimages.git'
+set :branch, 'main'
 
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
@@ -26,7 +28,8 @@ set :deploy_to, "/home/mimages/#{fetch :application}"
 set :linked_files, %w[db/production.sqlite3 config/master.key]
 
 # Default value for linked_dirs is []
-append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "tmp/webpacker", "public/system", "vendor", "storage"
+append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'tmp/webpacker', 'public/system', 'vendor',
+       'storage'
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # server-based syntax
 # ======================
 # Defines a single server with a list of roles and multiple properties.
@@ -6,8 +8,7 @@
 # server "example.com", user: "deploy", roles: %w{app db web}, my_property: :my_value
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}
-server "websrv5.brispace.net", user: "mimages", roles: %w{app db web}
-
+server 'websrv5.brispace.net', user: 'mimages', roles: %w[app db web]
 
 # role-based syntax
 # ==================
@@ -21,8 +22,6 @@ server "websrv5.brispace.net", user: "mimages", roles: %w{app db web}
 # role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
 # role :db,  %w{deploy@example.com}
 
-
-
 # Configuration
 # =============
 # You can set any configuration variable like in config/deploy.rb
@@ -32,7 +31,6 @@ server "websrv5.brispace.net", user: "mimages", roles: %w{app db web}
 # Feel free to add new variables to customise your setup.
 
 set :passenger_restart_with_touch, true
-
 
 # Custom SSH Options
 # ==================

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
-require_relative "application"
+require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -19,12 +21,12 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join("tmp/caching-dev.txt").exist?
+  if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store
-    config.public_file_server.headers = { "Cache-Control" => "public, max-age=#{2.days.to_i}" }
+    config.public_file_server.headers = { 'Cache-Control' => "public, max-age=#{2.days.to_i}" }
   else
     config.action_controller.perform_caching = false
 
@@ -41,7 +43,7 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -46,26 +48,26 @@ Rails.application.configure do
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
-  config.assume_ssl = ENV["DISABLE_SSL"].blank?
+  config.assume_ssl = ENV['DISABLE_SSL'].blank?
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = ENV["DISABLE_SSL"].blank?
+  config.force_ssl = ENV['DISABLE_SSL'].blank?
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new(STDOUT)
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
-    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+  config.logger = ActiveSupport::Logger.new($stdout)
+                                       .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+                                       .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you
   # want to log everything, set the level to "debug".
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -93,7 +95,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Only use :id for inspections in production.
-  config.active_record.attributes_for_inspect = [ :id ]
+  config.active_record.attributes_for_inspect = [:id]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -15,10 +17,10 @@ Rails.application.configure do
   # this is usually not necessary, and can slow down your test suite. However, it's
   # recommended that you enable it in continuous integration systems to ensure eager
   # loading is working properly before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = ENV['CI'].present?
 
   # Configure public file server for tests with Cache-Control for performance.
-  config.public_file_server.headers = { "Cache-Control" => "public, max-age=#{1.hour.to_i}" }
+  config.public_file_server.headers = { 'Cache-Control' => "public, max-age=#{1.hour.to_i}" }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true
@@ -45,7 +47,7 @@ Rails.application.configure do
 
   # Unlike controllers, the mailer instance doesn't have any context about the
   # incoming request so you'll need to provide the :host parameter yourself.
-  config.action_mailer.default_url_options = { host: "www.example.com" }
+  config.action_mailer.default_url_options = { host: 'www.example.com' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 # Pin npm packages by running ./bin/importmap
 
-pin "application", preload: true
-pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
-pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
-pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
-pin_all_from "app/javascript/controllers", under: "controllers"
-pin "exifreader", to: "https://ga.jspm.io/npm:exifreader@4.12.0/src/exif-reader.js"
+pin 'application', preload: true
+pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true
+pin '@hotwired/stimulus', to: 'stimulus.min.js', preload: true
+pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js', preload: true
+pin_all_from 'app/javascript/controllers', under: 'controllers'
+pin 'exifreader', to: 'https://ga.jspm.io/npm:exifreader@4.12.0/src/exif-reader.js'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = "1.0"
+Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy.

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
-Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+Rails.application.config.filter_parameters += %i[
+  passw email secret token _key crypt salt certificate otp ssn
 ]

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 #
 # This file eases your Rails 7.2 framework defaults upgrade.

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :google_oauth2, ENV.fetch('GOOGLE_OAUTH_CLIENTID', '1017266744995-k9heo6bk78idvi7qu9kvs0a6ntrfj1mg.apps.googleusercontent.com'), ENV.fetch('GOOGLE_OAUTH_SECRET', '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')
+  provider :google_oauth2,
+           ENV.fetch('GOOGLE_OAUTH_CLIENTID'),
+           ENV.fetch('GOOGLE_OAUTH_SECRET')
 end

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide HTTP permissions policy. For further

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 Time::DATE_FORMATS[:short_date] = '%b %e, %Y'

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This configuration file will be evaluated by Puma. The top-level methods that
 # are invoked here are part of Puma's configuration DSL. For more information
 # about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
@@ -20,15 +22,15 @@
 # Any libraries that use a connection pool or another resource pool should
 # be configured to provide at least as many connections as the number of
 # threads. This includes Active Record's `pool` parameter in `database.yml`.
-threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
+threads_count = ENV.fetch('RAILS_MAX_THREADS', 3)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT", 3000)
+port ENV.fetch('PORT', 3000)
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
-pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
+pidfile ENV['PIDFILE'] if ENV['PIDFILE']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   # Health check for Once deployment
-  get "up", to: proc { [200, {}, ["OK"]] }
+  get 'up', to: proc { [200, {}, ['OK']] }
 
-  get  "sign_in", to: "sessions#new"
-  delete  "sign_out", to: "sessions#destroy"
-  get  "/auth/failure",            to: "sessions/omniauth#failure"
-  get  "/auth/:provider/callback", to: "sessions/omniauth#create"
-  post "/auth/:provider/callback", to: "sessions/omniauth#create"
+  get 'sign_in', to: 'sessions#new'
+  delete 'sign_out', to: 'sessions#destroy'
+  get  '/auth/failure',            to: 'sessions/omniauth#failure'
+  get  '/auth/:provider/callback', to: 'sessions/omniauth#create'
+  post '/auth/:provider/callback', to: 'sessions/omniauth#create'
 
-  root "photos#index"
+  root 'photos#index'
 
-  resources :photos, only: [:show, :destroy], path: "v1/photos", param: :uuid
+  resources :photos, only: %i[show destroy], path: 'v1/photos', param: :uuid
   resources :photos, param: :uuid do
     get 'map', on: :member
   end

--- a/db/migrate/20230501030216_create_photos.rb
+++ b/db/migrate/20230501030216_create_photos.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePhotos < ActiveRecord::Migration[7.0]
   def change
     create_table :photos do |t|

--- a/db/migrate/20230501034811_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20230501034811_create_active_storage_tables.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change
@@ -19,7 +21,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
         t.datetime :created_at, null: false
       end
 
-      t.index [ :key ], unique: true
+      t.index [:key], unique: true
     end
 
     create_table :active_storage_attachments, id: primary_key_type do |t|
@@ -33,7 +35,8 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
         t.datetime :created_at, null: false
       end
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.index %i[record_type record_id name blob_id], name: :index_active_storage_attachments_uniqueness,
+                                                      unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
@@ -41,17 +44,18 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.belongs_to :blob, null: false, index: false, type: foreign_key_type
       t.string :variation_digest, null: false
 
-      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.index %i[blob_id variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end
 
   private
-    def primary_and_foreign_key_types
-      config = Rails.configuration.generators
-      setting = config.options[config.orm][:primary_key_type]
-      primary_key_type = setting || :primary_key
-      foreign_key_type = setting || :bigint
-      [primary_key_type, foreign_key_type]
-    end
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
 end

--- a/db/migrate/20230509030224_create_users.rb
+++ b/db/migrate/20230509030224_create_users.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class CreateUsers < ActiveRecord::Migration[7.0]
   def change
     create_table :users do |t|
-      t.string :email,           null: false, index: { unique: true }
+      t.string :email, null: false, index: { unique: true }
 
       t.string :provider
       t.string :uid

--- a/db/migrate/20230509030225_create_sessions.rb
+++ b/db/migrate/20230509030225_create_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateSessions < ActiveRecord::Migration[7.0]
   def change
     create_table :sessions do |t|

--- a/db/migrate/20230510031406_drop_sessions.rb
+++ b/db/migrate/20230510031406_drop_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DropSessions < ActiveRecord::Migration[7.0]
   def change
     drop_table :sessions

--- a/db/migrate/20230514220053_add_allowed_uploader_to_users.rb
+++ b/db/migrate/20230514220053_add_allowed_uploader_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAllowedUploaderToUsers < ActiveRecord::Migration[7.0]
   def change
     change_table :users do |t|

--- a/db/migrate/20230515124136_add_user_id_to_photos.rb
+++ b/db/migrate/20230515124136_add_user_id_to_photos.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUserIdToPhotos < ActiveRecord::Migration[7.0]
   def change
     add_reference :photos, :user

--- a/db/migrate/20260408032856_add_service_name_to_active_storage_blobs.active_storage.rb
+++ b/db/migrate/20260408032856_add_service_name_to_active_storage_blobs.active_storage.rb
@@ -1,17 +1,19 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20190112182829)
 class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
   def up
     return unless table_exists?(:active_storage_blobs)
 
-    unless column_exists?(:active_storage_blobs, :service_name)
-      add_column :active_storage_blobs, :service_name, :string
+    return if column_exists?(:active_storage_blobs, :service_name)
 
-      if configured_service = ActiveStorage::Blob.service.name
-        ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
-      end
+    add_column :active_storage_blobs, :service_name, :string
 
-      change_column :active_storage_blobs, :service_name, :string, null: false
+    if (configured_service = ActiveStorage::Blob.service.name)
+      ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
     end
+
+    change_column :active_storage_blobs, :service_name, :string, null: false
   end
 
   def down

--- a/db/migrate/20260408032857_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20260408032857_create_active_storage_variant_records.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20191206030411)
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change
@@ -8,20 +10,21 @@ class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
       t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
       t.string :variation_digest, null: false
 
-      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.index %i[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end
 
   private
-    def primary_key_type
-      config = Rails.configuration.generators
-      config.options[config.orm][:primary_key_type] || :primary_key
-    end
 
-    def blobs_primary_key_type
-      pkey_name = connection.primary_key(:active_storage_blobs)
-      pkey_column = connection.columns(:active_storage_blobs).find { |c| c.name == pkey_name }
-      pkey_column.bigint? ? :bigint : pkey_column.type
-    end
+  def primary_key_type
+    config = Rails.configuration.generators
+    config.options[config.orm][:primary_key_type] || :primary_key
+  end
+
+  def blobs_primary_key_type
+    pkey_name = connection.primary_key(:active_storage_blobs)
+    pkey_column = connection.columns(:active_storage_blobs).find { |c| c.name == pkey_name }
+    pkey_column.bigint? ? :bigint : pkey_column.type
+  end
 end

--- a/db/migrate/20260408032858_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
+++ b/db/migrate/20260408032858_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20211119233751)
 class RemoveNotNullOnActiveStorageBlobsChecksum < ActiveRecord::Migration[6.0]
   def change

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,11 +1,15 @@
-require "test_helper"
+# frozen_string_literal: true
 
-class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
-  # test "connects with cookies" do
-  #   cookies.signed[:user_id] = 42
-  #
-  #   connect
-  #
-  #   assert_equal connection.user_id, "42"
-  # end
+require 'test_helper'
+
+module ApplicationCable
+  class ConnectionTest < ActionCable::Connection::TestCase
+    # test "connects with cookies" do
+    #   cookies.signed[:user_id] = 42
+    #
+    #   connect
+    #
+    #   assert_equal connection.user_id, "42"
+    # end
+  end
 end

--- a/test/controllers/photos_controller_test.rb
+++ b/test/controllers/photos_controller_test.rb
@@ -1,12 +1,14 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class PhotosControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
+  test 'should get index' do
     get photos_index_url
     assert_response :success
   end
 
-  test "should get show" do
+  test 'should get show' do
     get photos_show_url
     assert_response :success
   end

--- a/test/models/photo_test.rb
+++ b/test/models/photo_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class PhotoTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,17 @@
-ENV["RAILS_ENV"] ||= "test"
-require_relative "../config/environment"
-require "rails/test_help"
+# frozen_string_literal: true
 
-class ActiveSupport::TestCase
-  # Run tests in parallel with specified workers
-  parallelize(workers: :number_of_processors)
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+require 'rails/test_help'
 
-  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  fixtures :all
+module ActiveSupport
+  class TestCase
+    # Run tests in parallel with specified workers
+    parallelize(workers: :number_of_processors)
 
-  # Add more helper methods to be used by all tests here...
+    # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+    fixtures :all
+
+    # Add more helper methods to be used by all tests here...
+  end
 end


### PR DESCRIPTION
## Summary
- Run `rubocop -A` to auto-correct style offenses (frozen string literals, indentation, etc.)
- Remove hardcoded Google OAuth credentials from `omniauth.rb` — now reads strictly from `GOOGLE_OAUTH_CLIENTID` and `GOOGLE_OAUTH_SECRET` env vars

This commit was on the `rails-7.2-upgrade` branch but landed after PR #35 was merged.

## Test plan
- [x] `rubocop` reports 22 remaining offenses (all in migrations, not auto-correctable)
- [ ] Verify `GOOGLE_OAUTH_CLIENTID` and `GOOGLE_OAUTH_SECRET` env vars are set in deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)