### PR TITLE
Read Maps API key from ENV instead of credentials

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -38,7 +38,7 @@ class PhotosController < ApplicationController
       'https://maps.googleapis.com',
       request: { timeout: 5 },
       params: {
-        key: Rails.application.credentials[:maps_api_key],
+        key: ENV.fetch('GOOGLE_MAPS_API_KEY'),
         channel: Rails.env
       }
     )


### PR DESCRIPTION
## Summary
- Replace `Rails.application.credentials[:maps_api_key]` with `ENV.fetch('GOOGLE_MAPS_API_KEY')` in photos controller
- All secrets are now environment variables, eliminating the need for `RAILS_MASTER_KEY` in the Once deployment

## ENV vars needed
| Variable | Purpose |
|----------|---------|
| `GOOGLE_MAPS_API_KEY` | Google Static Maps API |
| `GOOGLE_OAUTH_CLIENTID` | Google OAuth login |
| `GOOGLE_OAUTH_SECRET` | Google OAuth login |

## Test plan
- [ ] Set `GOOGLE_MAPS_API_KEY` in Once environment
- [ ] Verify map view renders on photo detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)