### PR TITLE
Fix Docker build: allow OAuth env vars to be absent at build time

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,6 +2,6 @@
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2,
-           ENV.fetch('GOOGLE_OAUTH_CLIENTID'),
-           ENV.fetch('GOOGLE_OAUTH_SECRET')
+           ENV['GOOGLE_OAUTH_CLIENTID'],
+           ENV['GOOGLE_OAUTH_SECRET']
 end


### PR DESCRIPTION
## Summary
- Change `ENV.fetch` to `ENV[]` for OAuth vars in omniauth initializer
- `ENV.fetch` crashes during `rails assets:precompile` in the Docker build since the vars aren't set at build time

This fix was on the `env-maps-api-key` branch but didn't make it into PR #37.

## Test plan
- [ ] Docker image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)